### PR TITLE
Fix no test found message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased Changes
 
+* fix error message when no tests are found ([#7](https://github.com/jsdotlua/jest-lua/pull/7))
+
 ## 3.6.1 (2024-01-16)
 * Re-release of 3.6.0 with widened promise dependency that includes older versions for maximum flexibility ([#378](https://github.com/Roblox/jest-roblox-internal/pull/378))
 

--- a/src/jest-core/src/runJest.lua
+++ b/src/jest-core/src/runJest.lua
@@ -318,16 +318,11 @@ local function runJest(ref: {
 		local hasTests = #allTests > 0
 
 		if not hasTests then
-			local noTestsFoundMessage = getNoTestsFoundMessage(testRunData, globalConfig)
+			local noTestsFound = getNoTestsFoundMessage(testRunData, globalConfig)
+			local exitWith0 = noTestsFound.exitWith0
+			local noTestsFoundMessage = noTestsFound.message
 
-			if
-				globalConfig.passWithNoTests
-				-- ROBLOX deviation START: not supported
-				-- or globalConfig.findRelatedTests
-				-- or globalConfig.lastCommit
-				-- or globalConfig.onlyChanged
-				-- ROBLOX deviation END
-			then
+			if exitWith0 then
 				CustomConsole.new(outputStream, outputStream):log(noTestsFoundMessage)
 			else
 				CustomConsole.new(outputStream, outputStream):error(noTestsFoundMessage)


### PR DESCRIPTION
Found a small bug when running jest without any tests, the message printed was a table instead of the actual message

