### PR TITLE
Fix resolve config path warning when multiple configs found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# Jest Lua Changelog
+  # Jest Lua Changelog
 
 ## Unreleased Changes
 
+* fix warning when multiple configuration are found ([#8](https://github.com/jsdotlua/jest-lua/pull/8))
 * fix error message when no tests are found ([#7](https://github.com/jsdotlua/jest-lua/pull/7))
 
 ## 3.6.1 (2024-01-16)

--- a/src/jest-config/src/constants.lua
+++ b/src/jest-config/src/constants.lua
@@ -21,7 +21,7 @@ local exports = {}
 -- ROBLOX deviation END
 local JEST_CONFIG_BASE_NAME = "jest.config"
 exports.JEST_CONFIG_BASE_NAME = JEST_CONFIG_BASE_NAME
--- ROBLOX deviation START: not needed
+-- ROBLOX deviation START: not supported
 -- local JEST_CONFIG_EXT_CJS = ".cjs"
 -- exports.JEST_CONFIG_EXT_CJS = JEST_CONFIG_EXT_CJS
 -- local JEST_CONFIG_EXT_MJS = ".mjs"
@@ -30,16 +30,30 @@ exports.JEST_CONFIG_BASE_NAME = JEST_CONFIG_BASE_NAME
 -- exports.JEST_CONFIG_EXT_JS = JEST_CONFIG_EXT_JS
 -- local JEST_CONFIG_EXT_TS = ".ts"
 -- exports.JEST_CONFIG_EXT_TS = JEST_CONFIG_EXT_TS
--- local JEST_CONFIG_EXT_JSON = ".json"
--- exports.JEST_CONFIG_EXT_JSON = JEST_CONFIG_EXT_JSON
--- local JEST_CONFIG_EXT_ORDER = Object.freeze({
--- 	JEST_CONFIG_EXT_JS,
--- 	JEST_CONFIG_EXT_TS,
--- 	JEST_CONFIG_EXT_MJS,
--- 	JEST_CONFIG_EXT_CJS,
--- 	JEST_CONFIG_EXT_JSON,
--- })
--- exports.JEST_CONFIG_EXT_ORDER = JEST_CONFIG_EXT_ORDER
 -- ROBLOX deviation END
+local JEST_CONFIG_EXT_JSON = ".json"
+exports.JEST_CONFIG_EXT_JSON = JEST_CONFIG_EXT_JSON
+-- ROBLOX deviation START: support Lua and Luau extensions
+local JEST_CONFIG_EXT_LUA = ".lua"
+exports.JEST_CONFIG_EXT_LUA = JEST_CONFIG_EXT_LUA
+local JEST_CONFIG_EXT_LUAU = ".luau"
+exports.JEST_CONFIG_EXT_LUAU = JEST_CONFIG_EXT_LUAU
+-- ROBLOX deviation END
+local JEST_CONFIG_EXT_ORDER = {
+	-- ROBLOX deviation START: support Lua and Luau extensions
+	JEST_CONFIG_EXT_LUA,
+	JEST_CONFIG_EXT_LUAU,
+	-- ROBLOX deviation END
+	-- ROBLOX deviation START: not supported
+	-- JEST_CONFIG_EXT_JS,
+	-- JEST_CONFIG_EXT_TS,
+	-- JEST_CONFIG_EXT_MJS,
+	-- JEST_CONFIG_EXT_CJS,
+	-- ROBLOX deviation END
+	-- ROBLOX deviation START: not supported (but for now)
+	-- JEST_CONFIG_EXT_JSON,
+	-- ROBLOX deviation END
+}
+exports.JEST_CONFIG_EXT_ORDER = JEST_CONFIG_EXT_ORDER
 
 return exports


### PR DESCRIPTION
Found a spot where the translated js did not make sense, now it's fixed!