### PR TITLE
Fix build scripts on MacOS

### DIFF
--- a/scripts/build-roblox-model.sh
+++ b/scripts/build-roblox-model.sh
@@ -11,8 +11,8 @@ build_with_darklua_config () {
 
     mkdir -p roblox
 
-    cp -rL node_modules roblox
-    cp -r roblox-model roblox
+    cp -rL node_modules roblox/
+    cp -r roblox-model roblox/
 
     for module_path in roblox/roblox-model/*; do
         module_name=$(basename $module_path)

--- a/scripts/build-roblox-model.sh
+++ b/scripts/build-roblox-model.sh
@@ -11,8 +11,8 @@ build_with_darklua_config () {
 
     mkdir -p roblox
 
-    cp -rL node_modules/ roblox/
-    cp -r roblox-model/ roblox/
+    cp -rL node_modules roblox
+    cp -r roblox-model roblox
 
     for module_path in roblox/roblox-model/*; do
         module_name=$(basename $module_path)

--- a/scripts/build-wally-package.sh
+++ b/scripts/build-wally-package.sh
@@ -6,7 +6,7 @@ rm -rf roblox/node_modules
 
 mkdir -p roblox
 
-cp -rL node_modules roblox
+cp -rL node_modules roblox/
 
 ./scripts/remove-tests.sh roblox/node_modules
 

--- a/scripts/build-wally-package.sh
+++ b/scripts/build-wally-package.sh
@@ -6,7 +6,7 @@ rm -rf roblox/node_modules
 
 mkdir -p roblox
 
-cp -rL node_modules/ roblox/
+cp -rL node_modules roblox
 
 ./scripts/remove-tests.sh roblox/node_modules
 


### PR DESCRIPTION
I'm setting up the repo on MacOS and a problem I ran into is `cp -r foo/ bar/` is resulting in the _contents_ of the first dir being copied into the second. Apparently, for reasons unknown, omitting the trailing slash on the first dir will correctly copy _into_ the second dir

Before | After
--- | ---
<img width="239" alt="Screenshot 2024-04-06 at 8 41 18 PM" src="https://github.com/jsdotlua/jest-lua/assets/3081936/a90a2402-1175-47da-ab74-3f8ac43e6801"> | <img width="196" alt="Screenshot 2024-04-06 at 8 40 56 PM" src="https://github.com/jsdotlua/jest-lua/assets/3081936/ee8654e0-b939-4dc3-96ec-a282d27c557b">

Checklist before submitting:
* [ ] Added/updated relevant tests
* [ ] Added/updated documentation
