### PR TITLE
fix: Use single quotes in JestMockRbx.lua

### DIFF
--- a/roblox-model/JestMockRbx.lua
+++ b/roblox-model/JestMockRbx.lua
@@ -1,1 +1,1 @@
-return require("@pkg/@jsdotlua/jest-mock-rbx")
+return require('@pkg/@jsdotlua/jest-mock-rbx')


### PR DESCRIPTION
The double quotes in this file prevented me from running `yarn build-assets` because [`scripts/build-roblox-model.sh:20`](https://github.com/jsdotlua/jest-lua/blob/main/scripts/build-roblox-model.sh#L20) expected single quotes. Changing them to single quotes allows me to run the command without issue.